### PR TITLE
Add new scaffold for Intro to Editor

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -32,4 +32,4 @@ Core is in Open Alpha, which means it is still in early stages, with many featur
 
 ## About the Documentation
 
-The Core documentation is continuously written by Manticore and members of the Creator Community. To contribute, click the <a href="#" title="Edit this page" class="md-icon"></a> **Edit** icon to  any page of the documentation.
+The Core documentation is continuously written by Manticore and members of the Creator Community. To contribute, click the <a href="#" title="Edit this page" class="md-icon"></a> **Edit** icon on any page of the documentation.


### PR DESCRIPTION
Removes the references to closed alpha, hyperlinks organization section, formalizes language. 