### PR TITLE
Fix IsA assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Website Build Status](https://api.netlify.com/api/v1/badges/c0780d7f-a678-49fd-b50e-ffe26f95147f/deploy-status)](https://app.netlify.com/sites/manticore-docs/deploys) [![Build Status](https://github.com/ManticoreGamesInc/platform-documentation/workflows/Build%20&%20Deploy%20(Development)/badge.svg)](https://github.com/ManticoreGamesInc/platform-documentation/actions?query=workflow%3A%22Build+%26+Deploy+%28Development%29%22) [![Build Status](https://github.com/ManticoreGamesInc/platform-documentation/workflows/Build%20&%20Deploy%20(Production)/badge.svg)](https://github.com/ManticoreGamesInc/platform-documentation/actions?query=workflow%3A%22Build+%26+Deploy+%28Production%29%22)
 
-Welcome to the source of the official Core platform documentation! Please check out the [contribution](CONTRIBUTING.MD) document if you are interested in
+Welcome to the source of the official Core platform documentation! Please check out the [contribution](CONTRIBUTING.md) document if you are interested in
 helping out!
 
 ## Related Repositories

--- a/src/api/examples.md
+++ b/src/api/examples.md
@@ -58,7 +58,7 @@ There are five types of contexts, **Client Context**, **Non-Networked**, **Stati
 - Scripts can spawn objects inside a static context.
 - Scripts run on both the server and the client.
 - Useful for things reproduced easily on the client and server with minimal data (procedurally generated maps).
-    - Send a single networked value to synchronize the server and clients random number generators.
+    - Send a single networked value to synchronize the server and client's random number generators.
     - Saves hundreds of transforms being sent from the server to every client.
 
 !!! warning "Beware of desync issues!"

--- a/src/api/examples.md
+++ b/src/api/examples.md
@@ -58,7 +58,7 @@ There are five types of contexts, **Client Context**, **Non-Networked**, **Stati
 - Scripts can spawn objects inside a static context.
 - Scripts run on both the server and the client.
 - Useful for things reproduced easily on the client and server with minimal data (procedurally generated maps).
-    - Send a single networked value to synchronize the server and clientsâ€™ random number generators.
+    - Send a single networked value to synchronize the server and clients random number generators.
     - Saves hundreds of transforms being sent from the server to every client.
 
 !!! warning "Beware of desync issues!"
@@ -163,7 +163,7 @@ This example spawns a custom [link]Projectile and is not a result of using a Wea
 local projectileBodyTemplate = script:GetCustomProperty("ProjectileTemplate")
 
 function OnProjectileImpact(projectile, other, hitResult)
-    if other:IsA("Player") then
+    if other and other:IsA("Player") then
         local dmg = Damage.New(25)
         dmg:SetHitResult(hitResult)
         dmg.reason = DamageReason.NPC
@@ -552,7 +552,7 @@ Events.Connect("GameStateChanged", OnStateChanged)
 
 ### `Events.ConnectForPlayer(string eventName, function eventListener, [...])` / `Events.BroadcastToServer(string eventName, [...])`
 
-This event connection allows the server to listen for broadcasts that originate from clients. In this example, two scripts communicate over the network. The first one is in a Server Context and the second one is in a Client Context. The client cand send input data to the server, in this case their cursor's position.
+This event connection allows the server to listen for broadcasts that originate from clients. In this example, two scripts communicate over the network. The first one is in a Server Context and the second one is in a Client Context. The client can't send input data to the server, in this case their cursor's position.
 
 ```lua
 -- Server script
@@ -583,7 +583,7 @@ This event connection allows the server to send a message to all players. In thi
 local teamHasFlag = 0
 
 function OnBeginOverlap(trigger, other)
-    if other:IsA("Player") and other.team ~= teamHasFlag then
+    if other and other:IsA("Player") and other.team ~= teamHasFlag then
         teamHasFlag = other.team
 
         local resultCode, errorMsg = Events.BroadcastToAllPlayers("FlagCaptured", other.name, other.team)
@@ -984,7 +984,7 @@ Game.roundEndEvent:Connect(OnRoundEnd)
 
 ### `GetImpactPosition()` / `GetImpactNormal()`
 
-This example shows the power of `World.Raycast()` which returns data in the form of a `HitResult`. The physics calculation starts from the center of the camera and shoots forward. If the player is looking at something, then a reflection vector is calculated as if a shot rococheted from the surface. Debug information is drawn about the ray, the impact point and the reflection. This script must be placed under a Client Context and works best if the scene has objects or terrain.
+This example shows the power of `World.Raycast()` which returns data in the form of a `HitResult`. The physics calculation starts from the center of the camera and shoots forward. If the player is looking at something, then a reflection vector is calculated as if a shot ricocheted from the surface. Debug information is drawn about the ray, the impact point and the reflection. This script must be placed under a Client Context and works best if the scene has objects or terrain.
 
 ```lua
 function Tick()
@@ -1061,7 +1061,7 @@ local trigger = script.parent
 
 function OnBeginOverlap(theTrigger, player)
   -- The object's type must be checked because CoreObjects also overlap triggers
-    if player:IsA("Player") then
+    if player and player:IsA("Player") then
         player:TransferToGame("577d80/core-royale")
     end
 end
@@ -1149,7 +1149,7 @@ While scripting, you can assign "resources" to players. These are just integer v
 
 You can manipulate these values via several methods on the player class, as well as registering for an event when they are changed.
 
-This sample registeres a listener to ensure that values are in the [0-100] range, and demonstrates several examples of how to change the values.
+This sample registers a listener to ensure that values are in the [0-100] range, and demonstrates several examples of how to change the values.
 
 ```lua
 local resource2 = "CoinsCollected"
@@ -1238,8 +1238,8 @@ Vector3.New(1000, 0, 200), -- starting position
 Vector3.New(0, 0, -1))     -- direction
 
 myProjectile.impactEvent:Connect(function(projectile, other, hitresult)
-    print("Hit object: " .. other.name .. " with an impact normal of " .. tostring(hitresult:GetImpactNormal()))
-    if other:IsA("Player") then
+    print("Hit object: " .. (other or { name = "nil" }).name .. " with an impact normal of " .. tostring(hitresult:GetImpactNormal()))
+    if other and other:IsA("Player") then
         print("We hit player " .. other.name .. "!!!")
     end
 end)
@@ -1283,7 +1283,7 @@ end)
 
 If a projectile has its `homingTarget` set, and then the target disappears for some reason, it will fire a `HomingFailedEvent`. This is usually because the CoreObject that the projectile is following was `Destroy`ed, or the player it was following logged out.
 
-In this example, we spawn an object, fire a projectile at it, (and set the `homingTarget` property) and then immedietely remove the target, leaving the projectile to feel dejected and confused.
+In this example, we spawn an object, fire a projectile at it, (and set the `homingTarget` property) and then immediately remove the target, leaving the projectile to feel dejected and confused.
 
 ```lua
 -- A template of a basic cube, attached to the script as a custom property:
@@ -1311,7 +1311,7 @@ objectInWorld:Destroy()
 
 ### `Projectile.Destroy`
 
-Sometimes you will want to remove a projectile from the game even if it hasn't hit any targets yet.  When this is the case, the `Destroy()` function does what you need - it does exactly what the name implies - the projectile is immedietely removed from the game and no events are generated.
+Sometimes you will want to remove a projectile from the game even if it hasn't hit any targets yet.  When this is the case, the `Destroy()` function does what you need - it does exactly what the name implies - the projectile is immediately removed from the game and no events are generated.
 
 We can test if an object still exists via the Object:IsValid() function. This can be useful because sometimes things other than program code can remove an object from our game.  (Existing for longer than the `lifeSpan`, or colliding with an object, in the case of projectiles.)
 
@@ -1362,7 +1362,7 @@ print("This projectile's speed is " .. tostring(myProjectile.speed))
 
 ### `Projectile.gravityScale` / `Projectile.bouncesRemaining` / `Projectile.bounciness` / `Projectile.shouldBounceOnPlayers`
 
-By default, projectiles are destroyed when they impact a surface. If you set their `bouncesRemaining` though, whenever they hit a surface, they will lose one `bouncesRemaining` and ricochet off in a new direction. This can be used to simulate grenades, super balls, bouncing lasers, or similar. The amount of energy they lose (or gain!) from impact is controled via the `bounciness` property.
+By default, projectiles are destroyed when they impact a surface. If you set their `bouncesRemaining` though, whenever they hit a surface, they will lose one `bouncesRemaining` and ricochet off in a new direction. This can be used to simulate grenades, super balls, bouncing lasers, or similar. The amount of energy they lose (or gain!) from impact is controlled via the `bounciness` property.
 
 `gravityScale` can be used to change the trajectory of projectiles in flight. Setting it to 0 means that the projectiles are unaffected by gravity, and will simply fly in a straight line until they hit something. Setting it to greater than zero means that the projectile will arc downwards like a normal thrown object. And setting it to less than zero means the projectile will arc upwards like a helium balloon.
 
@@ -1466,7 +1466,7 @@ local propCubeTemplate = script:GetCustomProperty("CubeTemplate")
 
 function OnImpact(projectile, other, hitresult)
     --Count how many times each projectile hits the player:
-    if other:IsA("Player") then
+    if other and other:IsA("Player") then
         print("Urk! I've been shot!")
     end
 end
@@ -1488,7 +1488,7 @@ for i = -4, 4 do
     FireAtPlayer(Vector3.New(1000, 250 * i, 500), targetPlayer)
 end
 
--- Player will not be hit (and the hit messaage will never be printed) because
+-- Player will not be hit (and the hit message will never be printed) because
 -- the projectiles are all owned by the player.
 ```
 
@@ -1592,7 +1592,7 @@ Here is an example of a weapon script that tests if the projectiles came from an
 
 ```lua
 function OnImpact(projectile, other, hitresult)
-    if other:IsA("Player") then
+    if other and other:IsA("Player") then
         local damageScale = 1.0
         if projectile.sourceAbility ~= nil and projectile.sourceAbility.name == "FlameThrower" then
             local fireResistance = other:GetResource("fireResist")
@@ -1698,7 +1698,7 @@ local trigger = script.parent
 
 function OnBeginOverlap(theTrigger, player)
     -- The object's type must be checked because CoreObjects also overlap triggers, but we only call :Die() on players.
-    if player:IsA("Player") then
+    if player and player:IsA("Player") then
         player:Die()
     end
 end
@@ -1715,14 +1715,14 @@ local trigger = script.parent
 local activePlayers = {}
 
 function OnBeginOverlap(theTrigger, player)
-    if player:IsA("Player") then
+    if player and player:IsA("Player") then
         table.insert(activePlayers, player)
         print("The trigger contains " .. #activePlayers .. " players")
     end
 end
 
 function OnEndOverlap(theTrigger, player)
-    if (not player:IsA("Player")) then return end
+    if (not player or not player:IsA("Player")) then return end
 
     for i,p in ipairs(activePlayers) do
         if (p == player) then
@@ -1871,7 +1871,7 @@ local trigger = script.parent
 function OnBeginOverlap(theTrigger, player)
     local teamToReward = player.team
 
-    if (player:IsA("Player") and teamToReward ~= trigger.team) then
+    if (player and player:IsA("Player") and teamToReward ~= trigger.team) then
         Game.IncreaseTeamScore(teamToReward, 1)
         print("Team " .. teamToReward .. " score = " .. Game.GetTeamScore(teamToReward))
     end
@@ -2005,7 +2005,7 @@ print(myVector3)
 
 ### `Vector3.size` / `Vector3.sizeSquared`
 
-A lot of vector math requires knowing the magntude of a vector - i. e. if you think of the vector as a point, how far away is it from (0, 0, 0)?
+A lot of vector math requires knowing the magnitude of a vector - i. e. if you think of the vector as a point, how far away is it from (0, 0, 0)?
 
 In Lua, you can get that value via the `size` property.  There is also the `sizeSquared` property, which is sometimes useful as a slightly faster option.  (Typically used in distance comparisons, since if `a.size < b.size`, then `a.sizeSquared < b.sizeSquared`.)
 
@@ -2058,13 +2058,13 @@ print(Vector3.UP) -- (0, 0, 1)
 
 ### `Vector3+Vector3` / `Vector3+Number` / `Vector3-Vector3` / `Vector3-Number` / `Vector3*Vector3` / `Vector3*Number` / `Number*Vector3` / `Vector3/Vector3` / `Vector3/Number` / `-Vector3`
 
-Most arithmatic operators will work on Vector3s in straightforward ways.
+Most arithmetic operators will work on Vector3s in straightforward ways.
 
 ```lua
 local a = Vector3.New(1, 2, 3)
 local b = Vector3.New(4, 5, 6)
 
--- Adding and subtracting vectors is the same as adding or subtracting each of their compoents.
+-- Adding and subtracting vectors is the same as adding or subtracting each of their components.
 print(a + b) -- (5, 7, 9)
 print(b - a) -- (3, 3, 3)
 
@@ -2089,9 +2089,9 @@ print(-a) -- -1, -2, -3
 
 ### `Vector3.GetNormalized()` / `Vector3(..)` / `Vector3(^)`
 
-A Normalized vector is a vector who's magnitude (size) is equal to 1.0.  Vector3 variables have a `GetNormalized()` function, which returns this vaule.  It is equivalent to dividing the vector by its own size, and is useful in linear algebra.
+A Normalized vector is a vector who's magnitude (size) is equal to 1.0.  Vector3 variables have a `GetNormalized()` function, which returns this value.  It is equivalent to dividing the vector by its own size, and is useful in linear algebra.
 
-Dot Proudct and Cross Product are two other common linear algebra operations, which can be represented in Lua byh the `..` and `^` operators respectively.
+Dot Product and Cross Product are two other common linear algebra operations, which can be represented in Lua byh the `..` and `^` operators respectively.
 
 Here is a sample that uses these operations to determine if an object is aimed within 15 degrees of a player.
 

--- a/src/core_api.md
+++ b/src/core_api.md
@@ -16,7 +16,7 @@ Properties, functions, and events inherited by [CoreObject](#coreobject) types a
 
 At a high level, Core Lua types can be divided into two groups: Data structures and Objects. Data structures are owned by Lua, while Objects are owned by the engine and could be destroyed while still referenced by Lua. Objects all inherit from a single base type: Object. Data structures have no common parent. However, all data structures and Objects share a common `type` property, which is a string indicating its type. The value of the `type` property will match the section headings below, for example: "Ability", "Vector2", "CoreObject", etc. All Core types also share an `IsA()` function. The `IsA()` function can be passed a type name, and will return `true` if the value is that type or one of its subtypes, or will return `false` if it is not. For example, `myObject:IsA("StaticMesh")`.
 
-A lowercase type denotates a basic Lua type, such as `string` and `boolean`. You can learn more about Lua types from the official manual [here](https://www.lua.org/manual/2.2/section3_3.html). An uppercase type is a Core Type, such as `Player` and `CoreObject`.
+A lowercase type denotes a basic Lua type, such as `string` and `boolean`. You can learn more about Lua types from the official manual [here](https://www.lua.org/manual/2.2/section3_3.html). An uppercase type is a Core Type, such as `Player` and `CoreObject`.
 
 ### Ability
 

--- a/src/getting_started/other_platforms.md
+++ b/src/getting_started/other_platforms.md
@@ -25,7 +25,7 @@ Everything used to create games in Core is made up of Core Content. While outsid
 
 #### Core Content
 
-Core Content includes everything from basic shape objects to game components like health bars and spawn points, all customizable. Objects are all downloaded with Core on install, which makes for virtually instanteneous loading of Core games and assets.
+Core Content includes everything from basic shape objects to game components like health bars and spawn points, all customizable. Objects are all downloaded with Core on install, which makes for virtually instantaneous loading of Core games and assets.
 
 #### Community Content
 
@@ -45,7 +45,7 @@ Core players have persistent avatars that are used across Core games with custom
 
 ### Networking
 
-Core allows straight-forward networking through the Heirarchy with **Server Context** and **Client Context** folders, and one-click networking of objects through the interface.
+Core allows straight-forward networking through the Hierarchy with **Server Context** and **Client Context** folders, and one-click networking of objects through the interface.
 
 It also includes free server hosting and analytics, automatically creating more server instances for player overflow.
 

--- a/src/tutorials/abilities_advanced.md
+++ b/src/tutorials/abilities_advanced.md
@@ -174,17 +174,8 @@ Use the **[VFX section](weapons.md#adding-visual-effects)** of the simple weapon
         Type the below code to create variables for the `equipment` and the `ability`:
 
         ```lua
-        local EQUIPMENT = script:FindAncestorByType('Equipment')
-
-        if not EQUIPMENT:IsA('Equipment') then
-            error(script.name .. " should be part of Equipment object hierarchy.")
-        end
-
-        local ABILITY = script:FindAncestorByType('Ability')
-
-        if not ABILITY:IsA('Ability') then
-            error(script.name .. " should be part of Ability object hierarchy.")
-        end
+        local EQUIPMENT = assert(script:FindAncestorByType('Equipment'), script.name .. " should be part of Equipment object hierarchy.")
+        local ABILITY = assert(script:FindAncestorByType('Ability'), script.name .. " should be part of Ability object hierarchy.")
         ```
 
     2. The other variable we want to create is a reference to whether or not the player has died. We can use this to turn off the flying state if the player dies.
@@ -304,7 +295,7 @@ We're going to add the ability to focus zoom with right click for better aiming!
     2. To protect ourselves from putting this script in the wrong place, we can add an error check into the script. Beneath the above line, add:
 
         ```lua
-        if not WEAPON:IsA('Weapon') then
+        if not WEAPON then
             error(script.name .. " should be part of Weapon object hierarchy.")
         end
         ```
@@ -531,7 +522,7 @@ So let's get started on the server script!
 
         ```lua
         local WEAPON = script:FindAncestorByType('Weapon')
-        if not WEAPON:IsA('Weapon') then
+        if not WEAPON then
             error(script.name .. " should be part of Weapon object hierarchy.")
         end
         ```
@@ -682,7 +673,7 @@ For our Fire Staff, let's set it up to do double damage if a player gets a succe
 
         ```lua
         local WEAPON = script:FindAncestorByType('Weapon')
-        if not WEAPON:IsA('Weapon') then
+        if not WEAPON then
             error(script.name .. " should be part of Weapon object hierarchy.")
         end
         ```
@@ -804,7 +795,7 @@ The main thing to change for our ammo supply is to change the properties of the 
 
         ```lua
         function OnBeginOverlap(whichTrigger, other)
-            if other:IsA("Player") then
+            if other and other:IsA("Player") then
                 print(whichTrigger.name .. ": Begin Trigger Overlap with " .. other.name)
                 other:AddResource("embers",1)
                 print("Player has "..tostring(other:GetResource("embers")).." embers.")

--- a/src/tutorials/lua_basics_lightbulb.md
+++ b/src/tutorials/lua_basics_lightbulb.md
@@ -106,7 +106,7 @@ You could think of it in terms of sandwich making. For a task like slicing an in
 * hold object to cut properly
 * begin slicing
 
-But for each item you want to slice for the sandwich, you'd have to type out that whole list each time! That would mean so much typing for the tomates, cheese, pickles... If that were a function instead, then you could just type `SliceObject(tomato)` when you want to do all those steps at once.
+But for each item you want to slice for the sandwich, you'd have to type out that whole list each time! That would mean so much typing for the tomatoes, cheese, pickles... If that were a function instead, then you could just type `SliceObject(tomato)` when you want to do all those steps at once.
 
 So in order to be able to perform our task exactly when and how we want to, we're going to change `TutorialScript` so the `UI.PrintToScreen` call is within a function. We'll call this function `Init`.
 


### PR DESCRIPTION
- Fixed pattern where the documentation would advise calling the method `:IsA()` on a potentially `nil` value.
  - Previously, `script:FindAncestorByType('Equipment')` was validated by `IsA('Equipment')`, despite the fact `FindAncestorByType('Equipment')` returns `Equipment` or `nil`. This is wrong because `(nil):IsA('Equipment')` will error when attempting to index `nil`. Here's a clip of me trying to write equivalent [roblox-ts code](https://roblox-ts.github.io/) (shameless plug for a project I co-develop).
  ![HBZtZNmAp9](https://user-images.githubusercontent.com/15217173/80819848-63df6d00-8b9b-11ea-8238-0ab3725c6655.gif)
    ###### Note how the TypeScript type system automatically inserts a `?.` instead of a `.` because it knows `TOOL` is possibly `undefined` (`nil`). You can also see the inferred type at the end when I hover over the identifier `TOOL` with my mouse.
- Fixed broken CONTRIBUTING link. It was `CONTRIBUTING.MD`, but should be `CONTRIBUTING.md` (case sensitive)
- Fixed some basic typos