### PR TITLE
Updated CoreObject:Destroy() example

### DIFF
--- a/src/api/examples.md
+++ b/src/api/examples.md
@@ -1532,6 +1532,12 @@ template3.parent = template2
 
 ### <a id="function:CoreObject.Destroy"></a>CoreObject.Destroy
 
+```lua
+local obj = script.parent -- This is the object you would like to destroy/remove.
+
+obj:Destroy() -- This will destroy the object.
+```
+
 ### <a id="property:CoreObject.lifeSpan"></a>CoreObject.lifeSpan
 
 There are several ways of destroying coreobjects, and noticing when they are destroyed.


### PR DESCRIPTION
Updated CoreObject:Destroy() example.

It didn't have a proper example, so I added one. If necessary, I plan on contributing a lot more. I plan on adding an example for every function, property, etc. I want to make the platform easy to learn for beginners, and visual representation helps a lot, cause just simply reading is kinda boring.