### PR TITLE
Fix typo in networkedPropertyChangedEvent example

### DIFF
--- a/src/api/coreobject.md
+++ b/src/api/coreobject.md
@@ -708,7 +708,7 @@ script.networkedPropertyChangedEvent:Connect(function(coreObject, propertyName)
     print("The networked property [" .. coreObject.name .. "] just had its ["
             .. propertyName .. "] property changed.")
 
-    local newValue = script:GetCustomProperty(propertyName)
+    local newValue = coreObject:GetCustomProperty(propertyName)
     print("New value: " .. tostring(newValue))
 end)
 


### PR DESCRIPTION
# Fixed typo in networkedPropertyChangedEvent example

<!-- If this is your first time contributing and you want to get the shiny Documentation Contributor role on our Discord, please add your Discord username below -->
