### PR TITLE
Adding "Toggle Maximized Viewport" with key F11

### DIFF
--- a/src/editor_keybindings.md
+++ b/src/editor_keybindings.md
@@ -58,6 +58,7 @@ tags:
 | Slow Movement            | ++C++                | Hold To Slow Down Movement Rate                            | Viewport Active, Moving    |
 | Drag Zoom                | ++alt+right-button++ | Hold to Zoom In And Out - Up / Down Or Left / Right Drag   | Viewport Active            |
 | Fast Movement            | ++shift++            | Hold To Increase Movement Rate                             | Viewport Active, Moving    |
+| Maximized Viewport       | ++F11++              | Toggle maximize viewport when the focus is on the viewer   | Viewport Active            |
 
 ## Object Selection
 


### PR DESCRIPTION
# Description

Adding "Toggle Maximized Viewport" with key F11

## Type of change

- [] New content (non-breaking change which adds functionality)

<!-- If this is your first time contributing and you want to get the shiny Documentation Contributor role on our Discord, please add your Discord username below -->
