### PR TITLE
AI Activity Tutorial - Fixed wrong activity names

### DIFF
--- a/src/tutorials/ai_activity_tutorial.md
+++ b/src/tutorials/ai_activity_tutorial.md
@@ -146,7 +146,7 @@ function IdleActivity.stop(activity)
 end
 
 -- Instantiates and returns an AIActivity managed by the aiActivityHandler
-local IdleActivityInstance = aiActivityHandler:AddActivity("Idle", IdleActivity)
+local IdleActivityInstance = aiActivityHandler:AddActivity("IdleActivity", IdleActivity)
 
 -- Parameter table for defining the tick, tickHighestPriority, start, stop functions
 local CaptureActivity = {}
@@ -172,7 +172,7 @@ function CaptureActivity.stop(activity)
 end
 
 -- Instantiates and returns an AIActivity managed by the AiActivityHandler
-local CaptureActivityInstance = aiActivityHandler:AddActivity("Capture", CaptureActivity)
+local CaptureActivityInstance = aiActivityHandler:AddActivity("CaptureActivity", CaptureActivity)
 ```
 
 ## Implementing the Capture AI Activity


### PR DESCRIPTION
# Description

Confusing for beginners if not explicitly said in the tutorial as the Script Generator automatically add "Activity" at the end.
Maybe this is not the right way to fix this and activities should not have the "Activity" suffix?
In this case, it might be better to add a small paragraph explaining why, or maybe just update the Script Generator to avoid this behavior.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
