### PR TITLE
Algolia: Add `lang` as an extra attribute for faceting

### DIFF
--- a/algolia-config.json
+++ b/algolia-config.json
@@ -10,12 +10,17 @@
             ]
         },
         {
-            "url": "https://docs.coregames.com/(?P<lang>.*?)/",
-            "variables": {
-                "lang": ["en", "fr"]
+            "url": "https://docs.coregames.com/fr/",
+            "extra_attributes": {
+                "lang": "fr"
             }
         },
-        "https://docs.coregames.com"
+        {
+            "url": "https://docs.coregames.com/",
+            "extra_attributes": {
+                "lang": "en"
+            }
+        }
     ],
     "sitemap_urls": [
         "https://docs.coregames.com/sitemap.xml"
@@ -67,7 +72,8 @@
             "fr"
         ],
         "attributesForFaceting": [
-            "searchable(tags)"
+            "searchable(tags)",
+            "lang"
         ],
         "attributesToSnippet": [
             "content:10"


### PR DESCRIPTION
# Description

This should allow the search engine index our pages based on their language.

<!-- A #ticketNumber will be sufficient, delete if not applicable
Fixes #(issue) -->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change which adds functionality)

<!-- If this is your first time contributing and you want to get the shiny Documentation Contributor role on our Discord, please add your Discord username below -->
