### PR TITLE
Vehicle material api update

### DIFF
--- a/src/api/coregameinfo.md
+++ b/src/api/coregameinfo.md
@@ -23,6 +23,7 @@ Metadata about a published game on the Core platform.
 | `screenshotCount` | `integer` | The number of screenshots published with the game. | Read-Only |
 | `hasWorldCapture` | `boolean` | `true` if the game was published with a captured view of the world for use with portals. | Read-Only |
 | `isQueueEnabled` | `boolean` | `true` if the game was published with queueing enabled. | Read-Only |
+| `maxPlayers` | `number` | Returns the maximum number of players that can exist on one server instance of the game | Read-Only |
 
 ## Functions
 

--- a/src/api/materialslot.md
+++ b/src/api/materialslot.md
@@ -28,6 +28,9 @@ Contains data about a material slot on a static or animated mesh.
 | `GetUVTiling()` | [`Vector2`](vector2.md) | Returns a Vector2 of the U and V tiling values. | None |
 | `SetColor(Color)` | `None` | Set the color for this slot. | None |
 | `GetColor()` | [`Color`](color.md) | Returns the color of this slot. | None |
+| `ResetColor()` | `None` | Resets the color of the material to the color that was originally assigned to the material slot in the editor | None |
+| `ResetIsSmartMaterial()` | `None` | Resets the smart material status of the of the material to what was originally assigned in the editor | None |
+| `ResetUVTiling()` | `None` | Resets the UV tiling settings the of the material to what was originally assigned in the editor | None |
 
 ## Examples
 

--- a/src/api/vehicle.md
+++ b/src/api/vehicle.md
@@ -19,10 +19,12 @@ Vehicle is a CoreObject representing a vehicle that can be occupied and driven b
 | `camera` | [`Camera`](camera.md) | Returns the Camera used for the driver while they occupy the vehicle. | Read-Only |
 | `driverAnimationStance` | `string` | Returns the animation stance that will be applied to the driver while they occupy the vehicle. | Read-Only |
 | `mass` | `number` | Returns the mass of the vehicle in kilograms. | Read-Only |
-| `maxSpeed` | `number` | Returns the maximum speed of the vehicle in centimeters per second. | Read-Only |
-| `accelerationRate` | `number` | Returns the approximate acceleration rate of the vehicle in centimeters per second squared. | Read-Only |
-| `brakeStrength` | `number` | Returns the maximum deceleration of the vehicle when stopping. | Read-Only |
-| `tireFriction` | `number` | Returns the amount of friction tires or treads have on the ground. | Read-Only |
+| `maxSpeed` | `number` | The maximum speed of the vehicle in centimeters per second. Default value is 6000. | Read-Write |
+| `accelerationRate` | `number` | The approximate acceleration rate of the vehicle in centimeters per second squared. Default value is 470. | Read-Write |
+| `turnRadius` | `number` | The shortest radius a vehicle can make when turning. Default value is 530. | Read-Write |
+| `brakeStrength` | `number` | The maximum deceleration of the vehicle when stopping. Default value is 10. | Read-Write |
+| `coastBreakStrength` | `number` | The maximum deceleration the vehicle experiences when coasting. Default value is 1. | Read-Write |
+| `tireFriction` | `number` | The amount of friction tires or treads have on the ground. Default value is 5. | Read-Write |
 | `gravityScale` | `number` | Returns how much gravity affects this vehicle.  Default value is 1.9. | Read-Only |
 | `isAccelerating` | `boolean` | Returns `true` if the vehicle is currently accelerating. | Read-Only |
 | `isDriverHidden` | `boolean` | Returns `true` if the driver is made invisible while occupying the vehicle. | Read-Only |
@@ -173,13 +175,13 @@ local LETHAL_SPEED = 4000
 
 function OnDriverExited(vehicle, player)
     if MAX_SAFE_SPEED >= LETHAL_SPEED then return end
-    
+
     local speed = vehicle:GetVelocity().size
     print("Exit speed = " .. speed)
-    
+
     if not player.isDead and speed > MAX_SAFE_SPEED then
         local t = (speed - MAX_SAFE_SPEED) / (LETHAL_SPEED - MAX_SAFE_SPEED)
-        
+
         local amount = CoreMath.Lerp(0, player.maxHitPoints, t)
         if amount > 0 then
             local damage = Damage.New(amount)
@@ -304,7 +306,7 @@ function RateVehicle(vehicle)
     local accele = RateStat(vehicle.accelerationRate, ACCELE_MIN, ACCELE_MAX)
     local topSpeed = RateStat(vehicle.maxSpeed, TOP_SPEED_MIN, TOP_SPEED_MAX)
     local handling = RateStat(vehicle.tireFriction, HANDLING_MIN, HANDLING_MAX)
-    
+
     -- Print vehicle ratings to the Event Log
     print(vehicle.name)
     print("Acceleration: " .. accele)


### PR DESCRIPTION
# Description

## July 13th Patch API Page Updates:

Updated API page properties for the following objects:

- Vehicle
  .maxSpeed
  .accelerationRate
  .tireFriction
  .brakeStrength
  .turnRadius
  .coastBrakeStrength
- MaterialSlot
   .ResetMaterialId()
   .ResetUVTiling()
   .ResetColor()
   .ResetIsSmartMaterial()
- CoreGameInfo
   .maxPlayers

## Type of change

- [x] New content (non-breaking change which adds functionality)

**NOTE:** The `ResetMaterialId()` property does not seem to exist and may have been left out of the patch.