### PR TITLE
Super minor changes to one of the examples on weapon.

### DIFF
--- a/src/api/weapon.md
+++ b/src/api/weapon.md
@@ -162,7 +162,9 @@ See also: [Equipment.equippedEvent](equipment.md) | [CoreObject.FindAncestorByTy
 Example using:
 
 ### `ammoType`
+
 ### `isAmmoFinite`
+
 ### `currentAmmo`
 
 In this simple auto-reload script, the weapon's current ammo is monitored. If it goes to zero and the player has ammo of the correct type, then the reload ability is activated. This script only works in a client-context and expects the Reload ability to be assigned as a custom property.

--- a/src/api/weapon.md
+++ b/src/api/weapon.md
@@ -162,6 +162,8 @@ See also: [Equipment.equippedEvent](equipment.md) | [CoreObject.FindAncestorByTy
 Example using:
 
 ### `ammoType`
+### `isAmmoFinite`
+### `currentAmmo`
 
 In this simple auto-reload script, the weapon's current ammo is monitored. If it goes to zero and the player has ammo of the correct type, then the reload ability is activated. This script only works in a client-context and expects the Reload ability to be assigned as a custom property.
 


### PR DESCRIPTION
Added it so that on one of the examples it shows that it also uses `.isAmmoFinite` and `.currentAmmo`. I know this is super minor but its something I noticed when browsing docs.

# Description

On one of the examples in the weapon API, it didn't include all the properties it used.



## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue) (Not really a bug fix but more of a touchup/attention to detail.

<!-- If this is your first time contributing and you want to get the shiny Documentation Contributor role on our Discord, please add your Discord username below -->
