### PR TITLE
Add note about Events byte encoding

### DIFF
--- a/src/api/events.md
+++ b/src/api/events.md
@@ -46,6 +46,9 @@ The maximum size a networked event can send is 128 bytes and all networked event
     - Vector3
     - Vector4
 
+If working with Byte encoding, Events.Broadcast supports all 255 possible values per byte.
+Events.BroadcastToPlayer only supports UTF8 and the values 1-127 for ASCII.
+
 ## Examples
 
 Example using:

--- a/src/api/events.md
+++ b/src/api/events.md
@@ -46,9 +46,7 @@ The maximum size a networked event can send is 128 bytes and all networked event
     - Vector3
     - Vector4
 
-If working with Byte encoding, Events.Broadcast supports all 255 possible values per byte.
-
-Events.BroadcastToPlayer supports UTF8 but only the values 1-127 for ASCII.
+If strings are used to broadcast byte encoded data over the network (via Events.BroadcastToPlayer, Events.BroadcastToAllPlayers or Events.BroadcastToServer) then their characters must have ASCII values within the range 1-127. Strings used locally and not sent over the network (i. e. Events.Broadcast) can use the full 0-255 range.
 
 ## Examples
 

--- a/src/api/events.md
+++ b/src/api/events.md
@@ -47,7 +47,8 @@ The maximum size a networked event can send is 128 bytes and all networked event
     - Vector4
 
 If working with Byte encoding, Events.Broadcast supports all 255 possible values per byte.
-Events.BroadcastToPlayer only supports UTF8 and the values 1-127 for ASCII.
+
+Events.BroadcastToPlayer supports UTF8 but only the values 1-127 for ASCII.
 
 ## Examples
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. -->
Added in two lines to events API to clarify supported character sets for the broadcast types.

## Type of change

<!-- If this is your first time contributing and you want to get the shiny Documentation Contributor role on our Discord, please add your Discord username below -->
koala