### PR TITLE
Corrected: Function written in camel case

### DIFF
--- a/src/api/input.md
+++ b/src/api/input.md
@@ -176,7 +176,7 @@ local MOUSE_IMAGE = script:GetCustomProperty("MouseImage"):WaitForObject()
 local CONTROLLER_IMAGE = script:GetCustomProperty("ControllerImage"):WaitForObject()
 
 -- Fired when the input has changed.
-function UpdateInputImage(player, changedInputType)
+local function UpdateInputImage(player, changedInputType)
     -- Check the changed input type by comparing with the
     -- InputType enum.
     if changedInputType == InputType.KEYBOARD_AND_MOUSE then

--- a/src/api/input.md
+++ b/src/api/input.md
@@ -176,7 +176,7 @@ local MOUSE_IMAGE = script:GetCustomProperty("MouseImage"):WaitForObject()
 local CONTROLLER_IMAGE = script:GetCustomProperty("ControllerImage"):WaitForObject()
 
 -- Fired when the input has changed.
-local function updateInputImage(player, changedInputType)
+function UpdateInputImage(player, changedInputType)
     -- Check the changed input type by comparing with the
     -- InputType enum.
     if changedInputType == InputType.KEYBOARD_AND_MOUSE then
@@ -188,10 +188,10 @@ local function updateInputImage(player, changedInputType)
     end
 end
 
-Input.inputTypeChangedEvent:Connect(updateInputImage)
+Input.inputTypeChangedEvent:Connect(UpdateInputImage)
 
 -- Update the input type image first time
-updateInputImage(Game.GetLocalPlayer(), Input.GetCurrentInputType())
+UpdateInputImage(Game.GetLocalPlayer(), Input.GetCurrentInputType())
 ```
 
 See also: [CoreObject.GetCustomProperty](coreobject.md) | [Game.GetLocalPlayer](game.md) | [CoreObjectReference.WaitForObject](coreobjectreference.md) | [Input.GetCurrentInputType](input.md) | [KEYBOARD_AND_MOUSE](enums.md#keyboard_and_mouse)


### PR DESCRIPTION
# Description

In addition to changing the function to Pascal Case, I've never seen "local" in front of "function" either and am assuming it's most probably a typo, so it was removed. If there is a reason this function is camel-case, it should probably be explained, as this will confuse the heck out of new users. I'm confused and I'm working on two years in. The Lua Style Guide at Core says functions are Pascal Case.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

<!-- If this is your first time contributing and you want to get the shiny Documentation Contributor role on our Discord, please add your Discord username below -->

TaoOfChaos