### PR TITLE
Fixed: "Activate() function is client-only"

### DIFF
--- a/src/api/ability.md
+++ b/src/api/ability.md
@@ -248,7 +248,7 @@ Example using:
 
 ### `Activate`
 
-The Ability `Activate()` function is client-only, behaving as if the player had pressed the key binding. In order for a server gameplay decision to result in an ability activation, it must be communicated over the network somehow. In this example, a trigger overlap is representative of an arbitrary gameplay decision on the server. A broadcast message is sent to the client, who receives the event and activates the ability.
+The Ability `Activate()` function behaves as if the player had pressed the key binding. In order for a server gameplay decision to result in an ability activation, it must be communicated over the network somehow. In this example, a trigger overlap is representative of an arbitrary gameplay decision on the server. A broadcast message is sent to the client, who receives the event and activates the ability.
 
 Server script:
 


### PR DESCRIPTION
# Description

I don't think this function is client-only. I've been using it for months in a default context, albeit Networked. If it is client-only, that should be listed as a tag in the Functions section (currently, it's "None"). Further explanation of what happens next in the component's hidden scripts would be good, so creators can understand how it works, as Abilities are one of the most complex Core Components to work with for a variety of reasons.
<!-- A #ticketNumber will be sufficient, delete if not applicable
Fixes #(issue) -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

<!-- If this is your first time contributing and you want to get the shiny Documentation Contributor role on our Discord, please add your Discord username below -->

TaoOfChaos
