### PR TITLE
Small fix to CoreGameEventCollection.GetResults()

### DIFF
--- a/src/api/coregameeventcollection.md
+++ b/src/api/coregameeventcollection.md
@@ -41,7 +41,7 @@ function IsEventActive(refName)
     local collection = CorePlatform.GetGameEventsForGame(GAME_ID)
     for i, eventData in ipairs(collection:GetResults()) do
         if eventData.state == CoreGameEventState.ACTIVE
-        and eventData.referenceName == EVENT_REF_NAME then
+        and eventData.referenceName == refName then
             return true
         end
     end


### PR DESCRIPTION
The function IsEventActive() was using the custom property instead of the parameter, in comparison. The result is the same in this example, but was a mistake as it defeats the educational purpose of this additional function.

# Description

<!-- Please include a summary of the change and which issue is fixed. -->

<!-- A #ticketNumber will be sufficient, delete if not applicable
Fixes #(issue) -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change which adds functionality)

<!-- If this is your first time contributing and you want to get the shiny Documentation Contributor role on our Discord, please add your Discord username below -->
