### PR TITLE
Change mentions of "Panel" to "Window".

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,7 +100,7 @@ nav:
           - Object Generator: references/object_generator.md
           - Offline Storage: references/offline_storage.md
           - Party System: references/party_system.md
-          - Performance Panel: references/performance_panel.md
+          - Performance Window: references/performance_panel.md
           - Persistent Storage: references/persistent_storage.md
           - Play-Mode Profiler: references/profiler.md
           - Portals: references/portals.md

--- a/src/references/ai.md
+++ b/src/references/ai.md
@@ -50,7 +50,7 @@ There is a complete tutorial available for learning the AIActivityHandler throug
 
 ## AI Debugger
 
-The AI Debugger is a panel in the **Project Content** window that allows creators to see all AI Activity Handlers, create new ones, and enable/disable them for preview.
+The AI Debugger is a window that allows creators to see all AI Activity Handlers, create new ones, and enable/disable them for preview.
 
 ### Open the AI Debugger
 

--- a/src/references/cameras_and_settings.md
+++ b/src/references/cameras_and_settings.md
@@ -202,7 +202,7 @@ See the video below to see the difference when using a side scroller camera. The
 
 ### Controls
 
-The **Control** category in the **Properties** panel has properties to control how the player's character moves and rotates.
+The **Control** category in the **Properties** window has properties to control how the player's character moves and rotates.
 
 | Property | Description |
 | -------- | ----------- |

--- a/src/references/custom_properties.md
+++ b/src/references/custom_properties.md
@@ -53,7 +53,7 @@ There are 2 ways to add a tooltip to a custom property.
 
 1. When creating a custom property.
 
-    When a custom property is being created, there is an option in the **Add Property** panel to set the tooltip.
+    When a custom property is being created, there is an option in the **Add Property** window to set the tooltip.
 
     ![!Tooltip](../img/CustomProperties/AddPropertyTooltip.png){: .center loading="lazy" }
 
@@ -77,7 +77,7 @@ Custom properties can be placed inside custom categories. This can be a good way
 
 ### Create a Category
 
-When adding a new custom property, the **Add Property** panel has fields where a **Category** can be selected, or created, and a **Sub Category** can be selected, or created.
+When adding a new custom property, the **Add Property** window has fields where a **Category** can be selected, or created, and a **Sub Category** can be selected, or created.
 
 To create a new **Category**, click inside the **Category** field and type the category to be created. The same applies for **Sub Category**. A custom property can have a root **Category** and a **Sub Category**.
 
@@ -87,7 +87,7 @@ To create a new **Category**, click inside the **Category** field and type the c
 
 Adding a property to a **Category** or **Sub Category** can be done from 2 locations.
 
-1. Add Property Panel.
+1. Add Property Window.
 
     When creating a new custom property, clicking inside the **Category** field will list any existing categories that have been created. Select the category to add the custom property too. This also applies to **Sub Categories**.
 
@@ -95,13 +95,13 @@ Adding a property to a **Category** or **Sub Category** can be done from 2 locat
 
 2. Move to Category.
 
-    From the **Properties** panel, custom properties can be moved to a category. Right click on the custom property to be moved, select **Move To Category**, and select the category.
+    From the **Properties** window, custom properties can be moved to a category. Right click on the custom property to be moved, select **Move To Category**, and select the category.
 
     ![!Move to Category](../img/CustomProperties/MoveToCategory.png){: .center loading="lazy" }
 
 ### Rename or Delete Category
 
-Renaming or deleting categories can be done from the options panel from the **Properties** panel.
+Renaming or deleting categories can be done from the options panel from the **Properties** window.
 
 ![!Rename or Delete Category](../img/CustomProperties/RenameDeleteCategory.png){: .center loading="lazy" }
 

--- a/src/references/custom_properties.md
+++ b/src/references/custom_properties.md
@@ -53,7 +53,7 @@ There are 2 ways to add a tooltip to a custom property.
 
 1. When creating a custom property.
 
-    When a custom property is being created, there is an option in the **Add Property** window to set the tooltip.
+    When a custom property is being created, there is an option in the **Add Property** popup window to set the tooltip.
 
     ![!Tooltip](../img/CustomProperties/AddPropertyTooltip.png){: .center loading="lazy" }
 
@@ -77,7 +77,7 @@ Custom properties can be placed inside custom categories. This can be a good way
 
 ### Create a Category
 
-When adding a new custom property, the **Add Property** window has fields where a **Category** can be selected, or created, and a **Sub Category** can be selected, or created.
+When adding a new custom property, the **Add Property** popup window has fields where a **Category** can be selected, or created, and a **Sub Category** can be selected, or created.
 
 To create a new **Category**, click inside the **Category** field and type the category to be created. The same applies for **Sub Category**. A custom property can have a root **Category** and a **Sub Category**.
 
@@ -87,7 +87,7 @@ To create a new **Category**, click inside the **Category** field and type the c
 
 Adding a property to a **Category** or **Sub Category** can be done from 2 locations.
 
-1. Add Property Window.
+1. Add Property Popup Window.
 
     When creating a new custom property, clicking inside the **Category** field will list any existing categories that have been created. Select the category to add the custom property too. This also applies to **Sub Categories**.
 

--- a/src/references/damageable_objects.md
+++ b/src/references/damageable_objects.md
@@ -77,7 +77,7 @@ See [Damageable Object](api/damageableobject/) API for information and examples.
 
 ## Objects that Implement Damageable Interface
 
-Some objects implement the **Damageable** interface that allows for it to receive health, damage, and death behaviour. **Damageable Objects** have `hitPoints` and `maxHitPoints` properties in the **Damageable** category of the object **Properties** panel.
+Some objects implement the **Damageable** interface that allows for it to receive health, damage, and death behaviour. **Damageable Objects** have `hitPoints` and `maxHitPoints` properties in the **Damageable** category of the object **Properties** window.
 
 ![!Properties](../img/DamageableObjects/properties.png)
 *Properties of a Vehicle*

--- a/src/references/game_events.md
+++ b/src/references/game_events.md
@@ -114,7 +114,7 @@ Players can also unregister from events at anytime, this will remove the event f
 
 In the editor, there is a button component called **UI Event RSVP Button** that can be found in **Platform Tools**, in **Core Content**. This button can be used by players in game so they can register and unregister for an event. This button will also contain a countdown for when the event will begin.
 
-Each game event created will have a **Game Event Id** that can be copied and added to the **Event ID** property of the **UI Event RSVP Button** in the **Properties Panel**. If no ID is entered, or is invalid, then the button will be disabled.
+Each game event created will have a **Game Event Id** that can be copied and added to the **Event ID** property of the **UI Event RSVP Button** in the **Properties** window. If no ID is entered, or is invalid, then the button will be disabled.
 
 ![!Register For Event](../img/GameEvents/event_button.png){: .center loading="lazy" }
 

--- a/src/references/materials.md
+++ b/src/references/materials.md
@@ -167,7 +167,7 @@ Meshes can have an undefined range of material slots. For instance, a cube mesh 
 
 This can be done with the `:GetMaterialSlots()` function (or `:GetMaterialSlot(string)` if you already know the name of the **MaterialSlot** you are trying to get) of [StaticMesh](../api/staticmesh.md) and [AnimatedMesh](../api/animatedmesh.md). Then, you can loop through those materials slots to either edit or ignore them.
 
-For example, consider the **`Craftsman Roof 01 Corner In`** mesh. If you look at the properties panel while selecting a **CoreObject** that uses this mesh, you will see three different materials: **Roof**, **Ceiling**, and **Trim**.
+For example, consider the **`Craftsman Roof 01 Corner In`** mesh. If you look at the **Properties** window while selecting a **CoreObject** that uses this mesh, you will see three different materials: **Roof**, **Ceiling**, and **Trim**.
 
 ![Roof](../img/Materials/Roof.png){: .center loading="lazy" }
 

--- a/src/references/performance_panel.md
+++ b/src/references/performance_panel.md
@@ -1,14 +1,14 @@
 ---
 id: performance_estimation_panel
-name: Performance Estimation Panel
-title: Performance Estimation Panel
+name: Performance Estimation Window
+title: Performance Estimation Window
 tags:
     - Reference
 ---
 
-# Performance Estimation Panel
+# Performance Estimation Window
 
-The aim of the Performance Estimation panel is to provide Creators a way to estimate the performance of their game on various computers over the different video settings.
+The aim of the Performance Estimation window is to provide Creators a way to estimate the performance of their game on various computers over the different video settings.
 
 ![PerformancePanel](../img/getting_started/performance_panel.png){: .center loading="lazy" }
 
@@ -44,4 +44,4 @@ With both the visualizations, the key point to make is "**Lower is Better**". Th
     - The game is expected to run poorly.
     - The creator needs to walk through their scene and perform some content optimizations in order to get the game region out of the Red zone into the Yellow or Green zones.
 
-Again, it is worth reiterating that **this panel only serves to give an estimation of performance on other computers**, and should not be the only factor considered when thinking about how the game might actually run on players' computers. Playtests and player feedback is very valuable when it comes to understanding this aspect of game development.
+Again, it is worth reiterating that **this window only serves to give an estimation of performance on other computers**, and should not be the only factor considered when thinking about how the game might actually run on players' computers. Playtests and player feedback is very valuable when it comes to understanding this aspect of game development.

--- a/src/references/profiler.md
+++ b/src/references/profiler.md
@@ -10,7 +10,7 @@ tags:
 
 ## Overview
 
-The Core Editor has a dedicated Performance Panel to diagnose performance issues at game creation time, including running the game in Multiplayer Preview mode to simulate client-server scenarios.
+The Core Editor has a dedicated Performance Window to diagnose performance issues at game creation time, including running the game in Multiplayer Preview mode to simulate client-server scenarios.
 
 But games and especially multiplayer games are beasts of a complicated nature, and it is often much more helpful to have some view into diagnostics with real clients connected to a real server, and see how the same game actually performs on a variety of machines under different gameplay scenarios.
 

--- a/src/references/scenes.md
+++ b/src/references/scenes.md
@@ -12,19 +12,19 @@ tags:
 
 A **Scene** is a way to have different assets and logic for a specific part of the game. A game can be made up of many scenes (e.g. main menu, tutorial, different levels) that display different information, and usually there is some way for a **Player** to get from one scene to the other.
 
-All projects come with one scene by default called **Main**, which will be shown in the **Scenes** panel as the active scene.
+All projects come with one scene by default called **Main**, which will be shown in the **Scenes** window as the active scene.
 
 ## Creating a Scene
 
-Creating a **Scene** can be done from the **Scenes** panel. Clicking on the **Scenes** button at the top of the **Hierarchy** will open a panel that will show a list of all scenes for the project, and a **Create New Scene** button at the bottom of that list.
+Creating a **Scene** can be done from the **Scenes** window. Clicking on the **Scenes** button at the top of the **Hierarchy** will open a window that will show a list of all scenes for the project, and a **Create New Scene** button at the bottom of that list.
 
 ![Scene Button](../img/Scenes/scenes_button.png)
-![Scene Panel](../img/Scenes/scenes_panel.png)
-*Scenes button (left), Scenes panel (right)*
+![Scene Window](../img/Scenes/scenes_panel.png)
+*Scenes button (left), Scenes window (right)*
 {: .image-cluster}
 
-1. Open the **Scenes** panel.
-2. Click the **Create New Scene** button at the bottom of the **Scenes** panel.
+1. Open the **Scenes** window.
+2. Click the **Create New Scene** button at the bottom of the **Scenes** window.
 3. Enter a name for the new scene.
 
 When a new scene has been created, the creator will be asked if they want to load the new scene.
@@ -38,7 +38,7 @@ When a new scene has been created, the creator will be asked if they want to loa
 
 When loading a **Scene**, **Core** will unload all assets in the project **Hierarchy** (i.e. template instances, script instances, UI), and load all the assets for the scene that will be loaded. When loading a scene, make sure to save the current scene or progress will be lost. **Core** will notify the creator of any unsaved changes when attempting to switch scene.
 
-A **Scene** can be loaded by clicking on the scene name in the **Scene** panel.
+A **Scene** can be loaded by clicking on the scene name in the **Scene** window.
 
 Another way to load a scene is from the **Scene** options panel.
 
@@ -51,7 +51,7 @@ Another way to load a scene is from the **Scene** options panel.
 
 Each scene can have a different maximum amount of players allowed. For example, a social space scene could have 32 players, whereas another scene in your game could have 4 players.
 
-Changing the maximum amount of players per scene can be done by loading the scene first, and then changing the **Max Players** field value. The **Scenes** panel displays the maximum amount of players set for each scene.
+Changing the maximum amount of players per scene can be done by loading the scene first, and then changing the **Max Players** field value. The **Scenes** window displays the maximum amount of players set for each scene.
 
 ![!Max Players Per Scene](../img/Scenes/players_per_scene.png){: .center loading="lazy" }
 
@@ -59,7 +59,7 @@ Changing the maximum amount of players per scene can be done by loading the scen
 
 Any scene in the project can be renamed. Scenes can't share the same name as each other. If a scene is renamed to the same name as an existing scene in the project, then that new name will be appended an index. For example, if there is already a scene named "Tutorial", renaming another scene to "Tutorial" will be named "Tutorial_1".
 
-1. Open the **Scenes** panel.
+1. Open the **Scenes** window.
 2. Click the button to the right of the scene.
 3. Click **Rename Scene** from the options menu, and set the new name for the scene.
 
@@ -69,7 +69,7 @@ Any scene in the project can be renamed. Scenes can't share the same name as eac
 
 The main scene for a project, is the scene that will be loaded for players by default when entering your game. Any scene created can be set up as the main scene for the project. For example, if there is 2 scenes that have a different theme (i.e. Christmas vs Summer), it is easy to change which scene is the main one and republish your project. When players load your game, they will load the main scene first.
 
-1. Open the **Scenes** panel.
+1. Open the **Scenes** window.
 2. Click the button to the right of the scene.
 3. Click **Set as Main Scene** from the options menu.
 
@@ -85,7 +85,7 @@ Duplicating a scene is a good way to use an existing scene as a base. All assets
 
 When duplicating a scene, **Core** will name the duplicated scene the same name as the scene being duplicated, but append an index to the end so it is unique. For example, duplicating the scene "Opening Level" will be named "Opening Level_1".
 
-1. Open the **Scenes** panel.
+1. Open the **Scenes** window.
 2. Click the button to the right of the scene.
 3. Click **Duplicate Scene** from the options menu.
 
@@ -93,11 +93,11 @@ When duplicating a scene, **Core** will name the duplicated scene the same name 
 
 ## Include for Publish
 
-Scenes can be included or excluded when publishing a game. This can be done from the **Scenes** panel by clicking on the checkbox, or by selecting from the options menu.
+Scenes can be included or excluded when publishing a game. This can be done from the **Scenes** window by clicking on the checkbox, or by selecting from the options menu.
 
 If a scene is already set to **Include for Publish**, the option will change to **Exclude from Publish**.
 
-1. Open the **Scenes** panel.
+1. Open the **Scenes** window.
 2. Click the button to the right of the scene.
 3. Click **Include for Publish** from the options menu.
 
@@ -109,7 +109,7 @@ To delete a scene from your project, it can not be currently loaded, or set as t
 
 !!! info "**Core** will confirm if the scene should be deleted."
 
-1. Open the **Scenes** panel.
+1. Open the **Scenes** window.
 2. Click the button to the right of the scene.
 3. Click **Delete Scene** from the options menu.
 
@@ -119,7 +119,7 @@ To delete a scene from your project, it can not be currently loaded, or set as t
 
 Each scene created is a physical folder on your system. Only scenes that have been saved can be revealed in the explorer.
 
-1. Open the **Scenes** panel.
+1. Open the **Scenes** window.
 2. Click the button to the right of the scene.
 3. Click **Show Scene in Explorer** from the options menu.
 
@@ -127,7 +127,7 @@ Each scene created is a physical folder on your system. Only scenes that have be
 
 ## Publishing Scenes
 
-Publishing a game will allow creators to select which scenes to publish. If no scenes have been created, then the main scene will be selected by default. If there are new scenes added to your project, those scenes will need to be ticked in the *Scenes** panel, or from the publishing window.
+Publishing a game will allow creators to select which scenes to publish. If no scenes have been created, then the main scene will be selected by default. If there are new scenes added to your project, those scenes will need to be ticked in the **Scenes** window, or from the publishing window.
 
 Click on the **Publish Game** button to bring up the **Game Publishing Settings**.
 

--- a/src/references/script_debugger.md
+++ b/src/references/script_debugger.md
@@ -95,4 +95,4 @@ In the picture below, the execution flow for the current running script can be s
 
 ## Learn More
 
-[Intro to Scripting](../tutorials/scripting_intro.md) | [Lua Scripting Tutorial](../tutorials/lua_basics_helloworld.md) | [Advanced Scripting in Core](../tutorials/race_timer.md) | [Performance Panel](../getting_started/performance_panel/) | [AI Activity Tutorial](tutorials/ai_activity_tutorial/)
+[Intro to Scripting](../tutorials/scripting_intro.md) | [Lua Scripting Tutorial](../tutorials/lua_basics_helloworld.md) | [Advanced Scripting in Core](../tutorials/race_timer.md) | [Performance Window](../getting_started/performance_panel/) | [AI Activity Tutorial](tutorials/ai_activity_tutorial/)

--- a/src/references/teams.md
+++ b/src/references/teams.md
@@ -96,7 +96,7 @@ The **Game Settings** object has settings to control how teams can communicate w
 
 ### Game Chat
 
-The game chat category in the **Properties** panel has an option to change the **Chat Mode**. By default, this is set to **Team and All**.
+The game chat category in the **Properties** window has an option to change the **Chat Mode**. By default, this is set to **Team and All**.
 
 | Mode | Description |
 | ---- | ----------- |
@@ -109,7 +109,7 @@ The game chat category in the **Properties** panel has an option to change the *
 
 ### Voice Chat
 
-The voice chat category in the **Properties** panel has an option to change the **Voice Chat Mode**. By default this is set to **All**.
+The voice chat category in the **Properties** window has an option to change the **Voice Chat Mode**. By default this is set to **All**.
 
 | Mode | Description |
 | ---- | ----------- |

--- a/src/tutorials/ability_tutorial.md
+++ b/src/tutorials/ability_tutorial.md
@@ -120,7 +120,7 @@ For this tutorial, we are going to make the player wave hello.
 
         ![Ability Object in Hierarchy](../img/EditorManual/Abilities/EquipmentInHierarchy4.png "Ability Object in Hierarchy"){: .center loading="lazy" }
 
-    2. Rename the `Ability` object to "Wave" by clicking on the `Ability` object and pressing F2. This can also be done by right clicking and selecting "Rename", or by changing the name at the top of the **Properties** panel.
+    2. Rename the `Ability` object to "Wave" by clicking on the `Ability` object and pressing F2. This can also be done by right clicking and selecting "Rename", or by changing the name at the top of the **Properties** window.
 
     Now when the player picks up the equipment, they will automatically gain the `Ability`! Of course, we still need to set it up to cause the wave animation.
 

--- a/src/tutorials/boss_tutorial.md
+++ b/src/tutorials/boss_tutorial.md
@@ -36,7 +36,7 @@ In this tutorial you are going to create a multiplayer boss fight. Players will 
 
 You will be importing an asset from **Community Content** that will contain various components you will drop into the **Hierarchy** while you follow the tutorial.
 
-1. Open the **Community Content** panel.
+1. Open the **Community Content** window.
 2. Search for `Boss Fight Tutorial` by **CoreAcademy**.
 3. Click **Import**.
 

--- a/src/tutorials/cosmetic_tutorial.md
+++ b/src/tutorials/cosmetic_tutorial.md
@@ -33,7 +33,7 @@ In this tutorial you are going to create a cosmetic system for players so they c
 
 You will be importing an asset from **Community Content** that will contain various components you will drop into the **Hierarchy** while you follow the tutorial.
 
-1. Open the **Community Content** panel.
+1. Open the **Community Content** window.
 2. Search for `Cosmetic System Tutorial` by **CoreAcademy**.
 3. Click **Import**.
 

--- a/src/tutorials/game_events.md
+++ b/src/tutorials/game_events.md
@@ -359,7 +359,7 @@ Test the game and make sure the amount of coins in the UI for the player update 
 
 The **UI Event RSVP Button** can be added to the UI so that players can register and unregister for the game event from within your game. The button also will contain information about the game event state. For example, it will display the amount of time remaining until the game event begins.
 
-Add the **UI Event RSVP Button** from **Platform Tools** in **Core Content** to the **UI Container** you created earlier. Later on you will be adding the game event ID to the the **Event ID** property in the **Properties Panel**. For the moment, the button will tell you that there is no game event loaded.
+Add the **UI Event RSVP Button** from **Platform Tools** in **Core Content** to the **UI Container** you created earlier. Later on you will be adding the game event ID to the the **Event ID** property in the **Properties** window. For the moment, the button will tell you that there is no game event loaded.
 
 ![!Event Button](../img/GameEventsTutorial/event_button_added.png){: .center loading="lazy" }
 
@@ -371,7 +371,7 @@ From the events page, copy the **Game Event Id** for the game event you created 
 
 ### Set Event ID Property
 
-With the **Game Event Id** copied, paste it into the **Event ID** property in the **Properties Panel**.
+With the **Game Event Id** copied, paste it into the **Event ID** property in the **Properties** window.
 
 ![!Created Event](../img/GameEventsTutorial/update_event_button.png){: .center loading="lazy" }
 

--- a/src/tutorials/perks_tutorial.md
+++ b/src/tutorials/perks_tutorial.md
@@ -44,7 +44,7 @@ For further information about the **Perks Program**, see the [Perks Program refe
 
 You will be importing an asset from **Community Content** that will contain various components you will drop into the **Hierarchy** while you follow the tutorial.
 
-1. Open the **Community Content** panel.
+1. Open the **Community Content** window.
 2. Search for `Perks Tutorial` by **CoreAcademy**.
 3. Click **Import**.
 
@@ -103,7 +103,7 @@ You will use a trigger so you can detect when the player has entered the trigger
 
 Because the trigger is in a client context, you need to force collision on, otherwise you will not be able to detect when a player has entered the trigger volume.
 
-Click on the **Resource Shop Trigger**, and set the **Game Collision** property to **Force On** in the **Properties** panel. In doing so, the gizmo for the trigger volume will now show up in the scene view.
+Click on the **Resource Shop Trigger**, and set the **Game Collision** property to **Force On** in the **Properties** window. In doing so, the gizmo for the trigger volume will now show up in the scene view.
 
 ![!Collision On](../img/PerksTutorial/resource_shop_trigger_collision_on.png){: .center loading="lazy" }
 
@@ -125,7 +125,7 @@ Move the **Resource Shop Trigger** inside the Perks Shop. Place it in front of t
 
 When the **Resource Shop Trigger** has the `interactable` property set to true, the label of the **Resource Shop Trigger** will be shown to the player when they enter the **Resource Shop Trigger** volume.
 
-Set the **Interaction Label** property for the **Resource Shop Trigger** to `Resource Shop` in the **Properties** panel.
+Set the **Interaction Label** property for the **Resource Shop Trigger** to `Resource Shop` in the **Properties** window.
 
 ![!Trigger Label](../img/PerksTutorial/resource_shop_trigger_label.png){: .center loading="lazy" }
 
@@ -187,14 +187,14 @@ Do the following for each shop resource. Since 4 perks were created, then 4 item
 
 1. Drag the template **Perks Tutorial - Resource Shop Item** into the **Items** panel.
 2. Rename the item to one of the resources being sold (i.e. `Coins`).
-3. Open the group in the **Hierarchy** and set the **text** property for the **Amount** object in the **Properties** panel.
-4. Change the **Image** property for the **image** object in the **Properties** panel.
+3. Open the group in the **Hierarchy** and set the **text** property for the **Amount** object in the **Properties** window.
+4. Change the **Image** property for the **image** object in the **Properties** window.
 5. Select the **Button** object.
-6. Add the Perk for this item to the **Perk Reference** property in the **Properties** panel.
+6. Add the Perk for this item to the **Perk Reference** property in the **Properties** window.
 
 #### Setting Perk References
 
-The perk reference in the **Properties** panel can be set a few different ways:
+The perk reference in the **Properties** window can be set a few different ways:
 
 - Dragging the perk reference from the **Perks Manager** window onto the **Perk Reference** property.
 - Double clicking on the **Perk Reference** property and selecting the perk.
@@ -206,7 +206,7 @@ The perk reference in the **Properties** panel can be set a few different ways:
 
 The UI items added for each resource that will be sold in the shop, will need to be positioned so they are spaced apart.
 
-To visually see how the UI will look, you can temporarily set the **Visibility** to **Force On** in the properties panel for the **Resource Shop** panel in the **Hierarchy**.
+To visually see how the UI will look, you can temporarily set the **Visibility** to **Force On** in the **Properties** window for the **Resource Shop** panel in the **Hierarchy**.
 
 See how the items in the UI are overlapping.
 
@@ -216,7 +216,7 @@ See how the items in the UI are overlapping.
 
 The width of the **UI Image**, and a little spacing between each image is 165. Move each item after the first item by 165 for the **X Offset** property. You can use the **X Offset** field to handle the calculation each time for you by using the addition operator. For example, `165+165`.
 
-After all the images have been positioned, the **Resource Shop** panel **Visibility** property can be set to **Force Off** in the **Properties** panel.
+After all the images have been positioned, the **Resource Shop** panel **Visibility** property can be set to **Force Off** in the **Properties** window.
 
 <div class="mt-video" style="width:100%">
     <video autoplay muted playsinline controls loop class="center" style="width:100%">
@@ -1083,7 +1083,7 @@ A trigger will need to be added so you can detect when the player has entered th
 
 Because the trigger is in a client context, you need to force collision on, otherwise you will not be able to detect when a player has entered the trigger volume.
 
-Click on the **Tip Jar Trigger**, and set the **Game Collision** property to **Force On** in the **Properties** panel. In doing so, the gizmo for the trigger volume will now show up in the scene view.
+Click on the **Tip Jar Trigger**, and set the **Game Collision** property to **Force On** in the **Properties** window. In doing so, the gizmo for the trigger volume will now show up in the scene view.
 
 ![!Collision On](../img/PerksTutorial/tip_jar_trigger_collision_on.png){: .center loading="lazy" }
 
@@ -1105,7 +1105,7 @@ Move the **Tip Jar Trigger** in front of the tip jar pedestal, and resize it.
 
 When the **Tip Jar Trigger** has the `interactable` property set to true, the label of the **Tip Jar Trigger** will be shown to the player when they enter the **Tip Jar Trigger** volume.
 
-Set the **Interaction Label** property for the **Tip Jar Trigger** to `Give Tip` in the **Properties** panel.
+Set the **Interaction Label** property for the **Tip Jar Trigger** to `Give Tip` in the **Properties** window.
 
 ![!Trigger Label](../img/PerksTutorial/tip_jar_trigger_label.png){: .center loading="lazy" }
 
@@ -1127,7 +1127,7 @@ The tip jar template comes with some UI already set up. You will need to create 
 
 Create 3 perk buttons inside the **Items** group in the **Tip Jar** group. You can drag the **UI Perk Purchase Button** from **Perk Tools** in **Project Content** into your **Hierarchy**.
 
-For each perk added to the UI, drag the perk reference onto the **Perk Reference** property in the **Properties** panel.
+For each perk added to the UI, drag the perk reference onto the **Perk Reference** property in the **Properties** window.
 
 !!! tip "View Tip Jar UI"
     Turn on the **Visibility** of the **Tip Jar** panel to see the UI while you position the buttons.
@@ -1708,7 +1708,7 @@ A trigger will need to be added so you can detect when the player has entered th
 
 Because the trigger is in a client context, you need to force collision on, otherwise you will not be able to detect when a player has entered the trigger volume.
 
-Click on the **Sprint Boost Trigger**, and set the **Game Collision** property to **Force On** in the **Properties** panel. In doing so, the gizmo for the trigger volume will now show up in the scene view.
+Click on the **Sprint Boost Trigger**, and set the **Game Collision** property to **Force On** in the **Properties** window. In doing so, the gizmo for the trigger volume will now show up in the scene view.
 
 ![!Collision On](../img/PerksTutorial/sprint_boost_trigger_collision_on.png){: .center loading="lazy" }
 
@@ -1730,7 +1730,7 @@ Move the **Sprint Boost Trigger** in front of the base of the sprint boost objec
 
 When the **Sprint Boost Trigger** has the `interactable` property set to true, the label of the **Sprint Boost Trigger** will be shown to the player when they enter the **Sprint Boost Trigger** volume.
 
-Set the **Interaction Label** property for the **Sprint Boost Trigger** to `Purchase Sprint Boost` in the **Properties** panel.
+Set the **Interaction Label** property for the **Sprint Boost Trigger** to `Purchase Sprint Boost` in the **Properties** window.
 
 ![!Trigger Label](../img/PerksTutorial/sprint_boost_trigger_label.png){: .center loading="lazy" }
 
@@ -1746,7 +1746,7 @@ The sprint boost template comes with some UI already set up. You will need to cr
 
 Create one perk button inside the **Items** group in the **Sprint Boost** group. You can drag the **UI Perk Purchase Button** from **Perk Tools** in **Project Content** into your **Hierarchy**.
 
-Add the sprint boost perk to the **Perk Reference** property in the **Properties** panel.
+Add the sprint boost perk to the **Perk Reference** property in the **Properties** window.
 
 ![!Perk Button](../img/PerksTutorial/perk_button.png){: .center loading="lazy" }
 
@@ -2180,7 +2180,7 @@ A trigger will need to be added so you can detect when the player has entered th
 
 Because the trigger is in a client context, you need to force collision on, otherwise you will not be able to detect when a player has entered the trigger volume.
 
-Click on the **VIP Shop Trigger**, and set the **Game Collision** property to **Force On** in the **Properties** panel. In doing so, the gizmo for the trigger volume will now show up in the scene view.
+Click on the **VIP Shop Trigger**, and set the **Game Collision** property to **Force On** in the **Properties** window. In doing so, the gizmo for the trigger volume will now show up in the scene view.
 
 ![!Collision On](../img/PerksTutorial/vip_shop_trigger_collision_on.png){: .center loading="lazy" }
 
@@ -2223,7 +2223,7 @@ Both UI containers have their own set of perk buttons that need to have the **Pe
 
 #### Set 2D UI Perk References
 
-In the **UI** group, set the **Perk Reference** property in the **Properties** panel for each VIP perk found in the **Items** group.
+In the **UI** group, set the **Perk Reference** property in the **Properties** window for each VIP perk found in the **Items** group.
 
 Do this for Bronze, Silver, and Gold, by opening the group in the **Hierarchy** and finding **UI Perk Purchase Button**.
 
@@ -2233,7 +2233,7 @@ Do this for Bronze, Silver, and Gold, by opening the group in the **Hierarchy** 
 
 The **World UI** also has perk buttons that need the **Perk Reference** set for each one.
 
-In the **World UI** group, set the **Perk Reference** property in the **Properties** panel for each VIP perk.
+In the **World UI** group, set the **Perk Reference** property in the **Properties** window for each VIP perk.
 
 Do this for Bronze, Silver, and Gold, by opening the group in the **Hierarchy** and finding **UI Perk Purchase Button**.
 

--- a/src/tutorials/race_timer.md
+++ b/src/tutorials/race_timer.md
@@ -27,7 +27,7 @@ In this tutorial you are going to explore more of the **Core** API to make a rac
 ## Create Project and Track
 
 !!! tip "Community Content Track"
-    A track has been uploaded to **Community Content** to help you get started. This can be imported from the **Community Content** panel by searching for `Race Timer Tutorial - Track` by **CoreAcademy**.
+    A track has been uploaded to **Community Content** to help you get started. This can be imported from the **Community Content** window by searching for `Race Timer Tutorial - Track` by **CoreAcademy**.
 
 1. Create a new empty project.
 2. In the **Hierarchy** delete the object **Default Floor**.
@@ -953,7 +953,7 @@ Create a **UI Image** object and rename it to `Background`. Place this inside th
 
 Create a **UI Panel** object and rename it to `Timer Panel`. Place this inside the **Race Timer** image as a child. This panel will hold a few objects for the actual timer.
 
-![!Panel Properties](../img/RaceTimerTutorial/timer_panel_props.png){: .center loading="lazy" }
+![!Window Properties](../img/RaceTimerTutorial/timer_panel_props.png){: .center loading="lazy" }
 
 #### Create Panel Background Image
 

--- a/src/tutorials/weapons_tutorial.md
+++ b/src/tutorials/weapons_tutorial.md
@@ -62,7 +62,7 @@ So, let's get started!
 
     ![Basic Rifle](/img/EditorManual/Weapons/weaponModelLocation.png "Layers and layers of options, dude."){: .center loading="lazy" }
 
-The first thing to do is to navigate over to **Core Content**, and scroll down to the *GAME OBJECTS* section. Within **Gameplay Objects**, drag a **Weapon** into your project **Hierarchy** panel.
+The first thing to do is to navigate over to **Core Content**, and scroll down to the *GAME OBJECTS* section. Within **Gameplay Objects**, drag a **Weapon** into your project **Hierarchy** window.
 
 A `weapon` in the **Hierarchy** includes two `Ability` Objects and a `PickupTrigger` beneath it--these objects are "children" of the "parent" weapon object.
 
@@ -102,7 +102,7 @@ The in-editor window scene weapon will be completely "empty" having almost no vi
 
 #### Change the weapon model's position
 
-1. Make sure that within the weapon's **Properties** panel, the **Socket** property is set to `right_prop`.
+1. Make sure that within the weapon's **Properties** window, the **Socket** property is set to `right_prop`.
 
     For a full list of all possible sockets that you could use, check out the **[Lua API](../api/animations.md)**.
 
@@ -154,7 +154,7 @@ Weapons come with a property for Damage--setting this determines how much gettin
 !!! tip "Not All Weapons Need to Shoot"
     The weapon system can be used for things that aren't weapons! If you were making a bubble blower, or a fishing pole, perhaps you would set the damage to 0 and use different visual effects. The key is that this is what actually happens when the player uses the weapon!
 
-1. With the `weapon` itself selected in the **Hierarchy**, check the **Properties** panel. Here is where we can set the **Damage** property to whatever we would like. In this case, let's set it to 25, so it will take 4 shots to kill a player with 100 health.
+1. With the `weapon` itself selected in the **Hierarchy**, check the **Properties** window. Here is where we can set the **Damage** property to whatever we would like. In this case, let's set it to 25, so it will take 4 shots to kill a player with 100 health.
 2. Now the weapon is set up to work! Test it out by using **Multiplayer Preview mode**, with 4 players selected.
 
 #### Multiplayer Preview


### PR DESCRIPTION
Changed "Panel" to "Window" for any window that can be pulled out and redocked for consistency across docs, because what you are docking is a window to a panel, not a panel to a panel.

This also applies to the "Add Property" window, even though it isn't dockable, but pops up as a window.

