### PR TITLE
Link to CoreObject on Folder

### DIFF
--- a/src/api/folder.md
+++ b/src/api/folder.md
@@ -8,6 +8,6 @@ tags:
 
 # Folder
 
-Folder is a CoreObject representing a folder containing other objects.
+Folder is a [CoreObject](coreobject.md) representing a folder containing other objects.
 
-They have no properties or functions of their own, but inherit everything from CoreObject.
+They have no properties or functions of their own, but inherit everything from [CoreObject](coreobject.md).


### PR DESCRIPTION
# Description

Another small Quality of Life change: link to the CoreObject when referencing to CoreObject. This is more efficient for developers, instead of having to search for CoreObject manually.

It slightly annoyed me that there was no direct link, henceforth this edit 😅 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New content (non-breaking change which adds functionality)

<!-- If this is your first time contributing and you want to get the shiny Documentation Contributor role on our Discord, please add your Discord username below -->
xChris_vC#3792
