### PR TITLE
Add YouTube videos in references and tutorials

### DIFF
--- a/src/references/damageable_objects.md
+++ b/src/references/damageable_objects.md
@@ -94,4 +94,7 @@ Below is a list of some of the objects that implement the **Damageable** interfa
 
 ## Learn More
 
+<lite-youtube videoid="vhRsrpR4A_4" playlabel="Damageable Objects"></lite-youtube>
+{: .video-container }
+
 [DamageableObject](../api/damageableobject.md) | [Damageable](../api/damageable.md) | [Damage](../api/damage.md) | [AIActivity](../api/aiactivity.md) | [AIActivityHandler](../api/aiactivityhandler.md) | [Vehicles](../references/vehicles.md)

--- a/src/references/networking.md
+++ b/src/references/networking.md
@@ -145,3 +145,8 @@ Things you would usually place in a server context include:
 
 - Procedurally generated geometry that needs to have player collision
 - Complicated geometry that needs to be collidable, but only needs to move as a unit.
+
+## Learn More
+
+<lite-youtube videoid="MnPuWyN3oh4" playlabel="Networking"></lite-youtube>
+{: .video-container }

--- a/src/references/shared_storage.md
+++ b/src/references/shared_storage.md
@@ -94,4 +94,7 @@ Shared storage is available in a read-only format for players who are offline as
 
 ## Learn More
 
+<lite-youtube videoid="LsQexb5UZNI" playlabel="Shared Storage"></lite-youtube>
+{: .video-container }
+
 [Shared Storage on the Core Lua API](../api/storage.md) | [Offline Storage Reference](offline_storage.md) | [Shared Storage Examples](../api/storage.md#examples) | [NetReference on the Core API](../api/netreference.md) | [Persistent Storage Reference](persistent_storage.md)

--- a/src/tutorials/environment_art.md
+++ b/src/tutorials/environment_art.md
@@ -330,4 +330,7 @@ The final step is to add structures and props that finish the scene. See the [Co
 
 ## Learn More
 
+<lite-youtube videoid="KFYlOzx7wm0" playlistid="PLiTIshJkGqBNUC2D5R24wRJWi8d6Egxbn" playlabel="Environment Art"></lite-youtube>
+{: .video-container }
+
 [Custom Materials](materials.md) | [Complex Modeling](modeling.md) | [Community Content](community_content.md) | [Visual Effects](vfx_tutorial.md)

--- a/src/tutorials/modeling_basics.md
+++ b/src/tutorials/modeling_basics.md
@@ -123,3 +123,8 @@ Try adding your own garnishes using the techniques we used to make the pancakes.
 Through a combination of simple geometry, modified materials, and decals, you can create tons of different props of all shapes and sizes in Core. Experiment with different settings, shapes, and make sure to check out other people's creations in the Community Content folder for inspiration.
 
 ![ModelingBasics](../img/ModelingBasics/image15.png "Modeling Screenshot"){: .center loading="lazy" }
+
+## Learn More
+
+<lite-youtube videoid="tVGzlkq5dt0" playlabel="Modeling Basics"></lite-youtube>
+{: .video-container }

--- a/src/tutorials/vfx_tutorial.md
+++ b/src/tutorials/vfx_tutorial.md
@@ -619,3 +619,8 @@ Now you've got some basic effects set up for your treasure chest! You have learn
 In most cases you won't need to code to use the visual effects in Core. Often times templates will have a custom property for more effect templates, so you can make your own effects as templates and just drag and drop them into other content--just like the Fantasy Loot Bag we used.
 
 There are so many ways that you can make effects unique. By combining several of them, changing their properties dramatically, and using them connected through code you can change the timing and positions of effects in whatever ways you can dream up.
+
+## Learn More
+
+<lite-youtube videoid="a7e9IYfr76M" playlabel="VFX"></lite-youtube>
+{: .video-container }


### PR DESCRIPTION
Added YouTube videos in the bottom Learn More section for:

- Modeling Basics Tutorial
- Damageable Objects Reference
- VFX Tutorial
- Shared Storage Reference
- Networking Reference
- Environment Art Tutorial

Note: Playlist Id seems to not affect the Environment Art video, possibly out of date youtube-lite?