### PR TITLE
Redundant Text

### DIFF
--- a/src/api/player.md
+++ b/src/api/player.md
@@ -1165,8 +1165,6 @@ Example using:
 
 ### `privateNetworkedDataChangedEvent`
 
-### `FAILURE`
-
 In this example, a player's inventory data is transferred from server to client. The server first accesses permanent storage to see if the player has previously played the game. If not, their inventory is initialized with starting items. Then, the server uses the private networked data API to transfer this information to the client script. Client scripts cannot access storage directly, so they depend on this transfer in order to display to the user interface what's contained in the inventory. Furthermore, because the transfer is private, other players don't incur networking costs. Plus, knowing other players' inventories is not important for the gameplay in this case.
 
 ```lua


### PR DESCRIPTION
The word "FAILURE" just seems to be here without context and it's the only word fully capitalized. Could this be an error?

# Description

<!-- Please include a summary of the change and which issue is fixed. -->

<!-- A #ticketNumber will be sufficient, delete if not applicable
Fixes #(issue) -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change which adds functionality)

<!-- If this is your first time contributing and you want to get the shiny Documentation Contributor role on our Discord, please add your Discord username below -->
