### PR TITLE
Add Generic Images for Bindings

### DIFF
--- a/src/img/BindingSets/General/add_binding.png
+++ b/src/img/BindingSets/General/add_binding.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b14b37edb65f643174b3b654e4cd58a7c3e429bbdf4d264291f503567341e468
+size 153804

--- a/src/img/BindingSets/General/bindings_window.png
+++ b/src/img/BindingSets/General/bindings_window.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b18276ae95b7c095e220eedc96b4af161f3e2b4bd2e59362221c008cbe26b370
+size 404394

--- a/src/img/BindingSets/General/networked.png
+++ b/src/img/BindingSets/General/networked.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:371272d1ffc17287aff56e8dcac90837041764be7b0bf2dd6768297c850dcb02
+size 149131


### PR DESCRIPTION
Added generic images that can be used throughout docs when needing to explain how to add a binding.
