### PR TITLE
Update contexts.md

### DIFF
--- a/src/api/contexts.md
+++ b/src/api/contexts.md
@@ -57,7 +57,7 @@ There are six types of contexts, **Client Context**, **Non-Networked**, **Static
 - Scripts can spawn objects inside a static context.
 - Scripts run on both the server and the client.
 - Useful for things reproduced easily on the client and server with minimal data (procedurally generated maps).
-    - Send a single networked value to synchronize the server and client's random number generators.
+    - Send a single networked value to synchronize the server and client's random number generators. Avoid using `math.random` for this purpose as this is shared by all scripts and contexts and will not generate the same sequence of numbers per client. See [RandomStream](../api/randomstream.md)
     - Saves hundreds of transforms being sent from the server to every client.
 
 ### Local Context


### PR DESCRIPTION
# Description

Have experienced and seen many people get tripped up using math.random coupled with math.randomseed thinking this will generate the same sequence of randomness. Thought it would be appropriate to warn against this and link to RandomStream which is the solution.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
